### PR TITLE
chore: downgrade edition from "2024" to "2021"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "nested_enum_utils"
 version = "0.2.0"
-edition = "2024"
+edition = "2021"
 readme = "README.md"
 description = "Macros to provide conversions for nested enums"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Most of our crates are "edition2021"