### PR TITLE
test: Add test that common fields macro fails when used with a unit case

### DIFF
--- a/tests/compile_fail/common_fields_unit.rs
+++ b/tests/compile_fail/common_fields_unit.rs
@@ -1,0 +1,9 @@
+use nested_enum_utils::common_fields;
+
+#[common_fields({ x: u64 })]
+enum Enum {
+    A,
+    B {},
+}
+
+fn main() {}

--- a/tests/compile_fail/common_fields_unit.stderr
+++ b/tests/compile_fail/common_fields_unit.stderr
@@ -1,0 +1,7 @@
+error: Expected named variants in enum
+ --> tests/compile_fail/common_fields_unit.rs:3:1
+  |
+3 | #[common_fields({ x: u64 })]
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: this error originates in the attribute macro `common_fields` (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
It should only work for (possibly empty) struct cases

Unfortunately these compile fail tests are very fragile. But what can you do?